### PR TITLE
feat: add TLS and AWS checks to attack surface scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+reports/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# UAIYUMCISTHUMTSGYRUUK
+# SMBSEC Attack Surface Scanner
+
+Minimal cloud-native attack surface scanner with asynchronous FastAPI backend, SQLite storage, and HTML reporting.
+
+## Features
+- Subdomain discovery via crt.sh
+- DNS resolution and TCP port scanning
+- HTTP fingerprinting (status, server header, title)
+- TLS inspection and SSH banner grabbing
+- Basic compliance score (risky ports, HTTP without HTTPS, TLS issues, TLS 1.3 bonus)
+- AWS connector (assume-role) checking for public S3 buckets and AdministratorAccess users/groups
+
+## Usage
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Trigger a scan:
+```bash
+curl -s -X POST http://127.0.0.1:8000/scan -H 'content-type: application/json' -d '{"domain":"example.com"}'
+```
+
+Add AWS connector and run CSPM checks:
+```bash
+curl -s -X POST http://127.0.0.1:8000/connect/aws -H 'content-type: application/json' \
+  -d '{"role_arn":"arn:aws:iam::123456789012:role/SMBSECReadOnly","external_id":"EXTERNAL"}'
+curl -s -X POST http://127.0.0.1:8000/cspm/aws/run
+```

--- a/app/cspm_aws.py
+++ b/app/cspm_aws.py
@@ -1,0 +1,78 @@
+import boto3, json, time
+from botocore.config import Config
+
+def assume(role_arn: str, external_id: str, session_name: str = "smbsec-cspm"):
+    sts = boto3.client("sts", config=Config(retries={'max_attempts': 3}))
+    resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=session_name, ExternalId=external_id, DurationSeconds=1800)
+    creds = resp["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=creds["AccessKeyId"],
+        aws_secret_access_key=creds["SecretAccessKey"],
+        aws_session_token=creds["SessionToken"]
+    )
+
+def s3_public_findings(sess):
+    s3 = sess.client("s3", config=Config(retries={'max_attempts': 3}))
+    out = []
+    buckets = s3.list_buckets().get("Buckets", [])
+    for b in buckets:
+        name = b["Name"]
+        public = False
+        details = {}
+        try:
+            pab = s3.get_public_access_block(Bucket=name)
+            details["PublicAccessBlock"] = pab.get("PublicAccessBlockConfiguration", {})
+            cfg = details["PublicAccessBlock"]
+            if not any(cfg.values()):
+                public = True
+        except s3.exceptions.NoSuchPublicAccessBlockConfiguration:
+            public = True
+        except Exception as e:
+            details["PublicAccessBlock_error"] = str(e)
+        try:
+            pol_status = s3.get_bucket_policy_status(Bucket=name)
+            if pol_status.get("PolicyStatus", {}).get("IsPublic"):
+                public = True
+            details["PolicyStatus"] = pol_status
+        except Exception as e:
+            details["PolicyStatus_error"] = str(e)
+        try:
+            acl = s3.get_bucket_acl(Bucket=name)
+            grants = acl.get("Grants", [])
+            for g in grants:
+                grantee = g.get("Grantee", {})
+                if grantee.get("URI","").endswith("/AllUsers") or grantee.get("URI","").endswith("/AuthenticatedUsers"):
+                    public = True
+            details["ACL"] = acl
+        except Exception as e:
+            details["ACL_error"] = str(e)
+        if public:
+            out.append({"resource": f"s3://{name}", "issue": "Public S3 bucket", "details": details})
+    return out
+
+def iam_admin_findings(sess):
+    iam = sess.client("iam", config=Config(retries={'max_attempts': 3}))
+    out = []
+    admin_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+    users = iam.list_users().get("Users", [])
+    for u in users:
+        name = u["UserName"]
+        at = iam.list_attached_user_policies(UserName=name).get("AttachedPolicies", [])
+        for p in at:
+            if p["PolicyArn"] == admin_arn:
+                out.append({"resource": f"iam:user/{name}", "issue": "User has AdministratorAccess", "details": p})
+    groups = iam.list_groups().get("Groups", [])
+    for g in groups:
+        gname = g["GroupName"]
+        at = iam.list_attached_group_policies(GroupName=gname).get("AttachedPolicies", [])
+        for p in at:
+            if p["PolicyArn"] == admin_arn:
+                out.append({"resource": f"iam:group/{gname}", "issue": "Group has AdministratorAccess", "details": p})
+    return out
+
+def run_checks(role_arn: str, external_id: str):
+    sess = assume(role_arn, external_id)
+    findings = []
+    findings += s3_public_findings(sess)
+    findings += iam_admin_findings(sess)
+    return findings

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,108 @@
+import aiosqlite, asyncio, json, os, time
+DB_PATH = os.path.join(os.path.dirname(__file__), "..", "data.db")
+
+SCHEMA = """
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS scans(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  domain TEXT NOT NULL,
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER,
+  status TEXT NOT NULL CHECK(status IN ('queued','running','done','error')) DEFAULT 'queued',
+  stats_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS assets(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  scan_id INTEGER NOT NULL,
+  host TEXT NOT NULL,
+  ip TEXT,
+  first_seen INTEGER NOT NULL,
+  last_seen INTEGER NOT NULL,
+  UNIQUE(scan_id, host, ip)
+);
+CREATE TABLE IF NOT EXISTS findings(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  scan_id INTEGER NOT NULL,
+  host TEXT NOT NULL,
+  ip TEXT,
+  port INTEGER,
+  proto TEXT,
+  severity TEXT NOT NULL CHECK(severity IN ('info','low','medium','high','critical')),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS connectors(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  org TEXT NOT NULL DEFAULT 'default',
+  kind TEXT NOT NULL CHECK(kind IN ('aws')),
+  role_arn TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+"""
+
+async def init_db():
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.executescript(SCHEMA)
+        await db.commit()
+
+async def create_scan(domain:str)->int:
+    now = int(time.time())
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute("INSERT INTO scans(domain,started_at,status) VALUES(?,?,?)",
+                               (domain, now, 'running'))
+        await db.commit()
+        return cur.lastrowid
+
+async def finish_scan(scan_id:int, status:str, stats:dict):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("UPDATE scans SET finished_at=?, status=?, stats_json=? WHERE id=?",
+                         (int(time.time()), status, json.dumps(stats), scan_id))
+        await db.commit()
+
+async def upsert_asset(scan_id:int, host:str, ip:str|None):
+    now = int(time.time())
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO assets(scan_id,host,ip,first_seen,last_seen) VALUES(?,?,?,?,?)",
+            (scan_id, host, ip, now, now))
+        await db.execute(
+            "UPDATE assets SET last_seen=? WHERE scan_id=? AND host=? AND ifnull(ip,'')=ifnull(?, '')",
+            (now, scan_id, host, ip))
+        await db.commit()
+
+async def add_finding(scan_id:int, host:str, ip:str|None, port:int|None, proto:str|None,
+                      severity:str, title:str, description:str, evidence:dict):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("""INSERT INTO findings
+            (scan_id,host,ip,port,proto,severity,title,description,evidence_json,created_at)
+            VALUES(?,?,?,?,?,?,?,?,?,?)""",
+            (scan_id,host,ip,port,proto,severity,title,description,json.dumps(evidence),int(time.time())))
+        await db.commit()
+
+async def get_scan(scan_id:int)->dict|None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cur = await db.execute("SELECT * FROM scans WHERE id=?", (scan_id,))
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+async def list_findings(scan_id:int)->list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cur = await db.execute("SELECT * FROM findings WHERE scan_id=?", (scan_id,))
+        return [dict(r) for r in await cur.fetchall()]
+
+async def add_connector_aws(role_arn:str, external_id:str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("INSERT INTO connectors(org,kind,role_arn,external_id,created_at) VALUES(?,?,?,?,?)",
+                         ('default','aws',role_arn,external_id,int(time.time())))
+        await db.commit()
+
+async def get_connectors(kind:str='aws')->list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cur = await db.execute("SELECT * FROM connectors WHERE kind=?", (kind,))
+        return [dict(r) for r in await cur.fetchall()]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,139 @@
+import asyncio, json, os, time
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from pydantic import BaseModel
+from . import db, scanner
+from .report import render_report
+from .cspm_aws import run_checks
+
+app = FastAPI(title="SMBSEC MVP", version="0.1.0")
+
+class ScanRequest(BaseModel):
+    domain: str
+
+class AWSConnector(BaseModel):
+    role_arn: str
+    external_id: str
+
+@app.on_event("startup")
+async def startup():
+    await db.init_db()
+
+@app.post("/scan")
+async def start_scan(req: ScanRequest):
+    domain = req.domain.strip().lower()
+    if not domain or " " in domain or "." not in domain:
+        raise HTTPException(400, "Invalid domain")
+    scan_id = await db.create_scan(domain)
+    async def run():
+        stats = {"hosts":0,"open":0,"score":100,"penalties":[],"bonuses":[]}
+        try:
+            out = await scanner.scan_domain(domain)
+            for host, ips in out["host_ips"].items():
+                if not ips:
+                    await db.upsert_asset(scan_id, host, None)
+                for ip in ips:
+                    await db.upsert_asset(scan_id, host, ip)
+                    stats["hosts"] += 1
+            for (host, ip, port) in out["open_ports"]:
+                title = f"Open TCP {port}"
+                desc = "Service reachable from Internet"
+                sev = "medium"
+                await db.add_finding(scan_id, host, ip, port, "tcp", sev, title, desc, {})
+                stats["open"] += 1
+                if port in (3389, 5432, 6379, 3306):
+                    stats["score"] -= 10
+                    stats["penalties"].append(f"Risky port {port} exposed")
+            for key, fp in out["fingerprints"].items():
+                h, ip, p = key.split("|")
+                p = int(p)
+                if "status" in fp:
+                    title = f"HTTP {fp['status']} on port {p}"
+                    server = fp.get("server","")
+                    detail = f"Server: {server} Title: {fp.get('title','')}"
+                    await db.add_finding(scan_id, h, ip, p, "http", "low", title, detail, fp)
+                if p in (80, 8080):
+                    has_https = any(x for x in out["open_ports"] if x[0]==h and x[1]==ip and x[2] in (443,8443))
+                    if not has_https:
+                        stats["score"] -= 5
+                        stats["penalties"].append("HTTP exposed without HTTPS")
+            for key, info in out.get("tls", {}).items():
+                h, ip, p = key.split("|"); p = int(p)
+                if info:
+                    days = info.get("days_to_expiry")
+                    proto = info.get("protocol","")
+                    if isinstance(days, int):
+                        if days < 0:
+                            await db.add_finding(scan_id, h, ip, p, "tls", "high",
+                                "Expired TLS certificate", "Certificate notAfter date is in the past", info)
+                            stats["score"] -= 15
+                            stats["penalties"].append("Expired TLS cert")
+                        elif days < 14:
+                            await db.add_finding(scan_id, h, ip, p, "tls", "medium",
+                                "TLS certificate expiring soon", f"Cert expires in {days} days", info)
+                    if proto and proto.startswith("TLSv1.3"):
+                        stats["score"] += 2
+                        stats["bonuses"].append("TLS 1.3 detected")
+            for key, banner in out.get("ssh", {}).items():
+                if banner:
+                    h, ip, p = key.split("|"); p = int(p)
+                    await db.add_finding(scan_id, h, ip, p, "ssh", "info",
+                        "SSH service banner", banner, {"banner": banner})
+        except Exception as e:
+            await db.finish_scan(scan_id, "error", {"error": str(e)})
+            return
+        await db.finish_scan(scan_id, "done", stats)
+    asyncio.create_task(run())
+    return {"scan_id": scan_id, "status": "running"}
+
+@app.get("/scans/{scan_id}")
+async def get_scan(scan_id:int):
+    s = await db.get_scan(scan_id)
+    if not s: raise HTTPException(404, "Not found")
+    f = await db.list_findings(scan_id)
+    return {"scan": s, "findings": f}
+
+@app.get("/report/{scan_id}", response_class=HTMLResponse)
+async def get_report(scan_id:int):
+    s = await db.get_scan(scan_id)
+    if not s: raise HTTPException(404, "Not found")
+    if s["status"] not in ("done","error"):
+        return HTMLResponse("<h3>Scan still running...</h3>")
+    import aiosqlite
+    async with aiosqlite.connect(os.path.join(os.path.dirname(__file__), "..", "data.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        a = await conn.execute("SELECT host, ip, last_seen FROM assets WHERE scan_id=?", (scan_id,))
+        assets = [dict(r) for r in await a.fetchall()]
+    f = await db.list_findings(scan_id)
+    stats = json.loads(s.get("stats_json", "{}"))
+    html = render_report(scan_id, s["domain"], s["finished_at"] or int(time.time()), assets, f, stats)
+    out_path = os.path.join(os.path.dirname(__file__), "..", "reports", f"scan_{scan_id}.html")
+    with open(out_path, "w", encoding="utf-8") as fp:
+        fp.write(html)
+    return HTMLResponse(html)
+
+@app.post("/connect/aws")
+async def connect_aws(conn: AWSConnector):
+    await db.add_connector_aws(conn.role_arn.strip(), conn.external_id.strip())
+    return {"status": "ok"}
+
+@app.post("/cspm/aws/run")
+async def cspm_run():
+    conns = await db.get_connectors('aws')
+    if not conns:
+        raise HTTPException(400, "No AWS connector configured")
+    role_arn = conns[0]["role_arn"]
+    external_id = conns[0]["external_id"]
+    scan_id = await db.create_scan("aws")
+    try:
+        results = run_checks(role_arn, external_id)
+        for it in results:
+            title = it["issue"]
+            res = it["resource"]
+            sev = "high" if "AdministratorAccess" in title or "Public" in title else "medium"
+            await db.add_finding(scan_id, host=res, ip=None, port=None, proto="aws", severity=sev,
+                                 title=title, description=f"AWS check flagged: {res}", evidence=it)
+        await db.finish_scan(scan_id, "done", {"count": len(results)})
+    except Exception as e:
+        await db.finish_scan(scan_id, "error", {"error": str(e)})
+    return {"scan_id": scan_id}

--- a/app/probers.py
+++ b/app/probers.py
@@ -1,0 +1,35 @@
+import socket, ssl, datetime, asyncio
+
+def get_tls_cert_info(host: str, port: int = 443, timeout: float = 3.0) -> dict:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    info = {}
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        with ctx.wrap_socket(sock, server_hostname=host) as ssock:
+            cert = ssock.getpeercert()
+            cipher = ssock.cipher()
+            proto = ssock.version()
+            info["protocol"] = proto
+            info["cipher"] = cipher[0] if cipher else ""
+            info["issuer"] = " ".join(["=".join(t) for tup in cert.get("issuer", []) for t in tup])
+            info["subject"] = " ".join(["=".join(t) for tup in cert.get("subject", []) for t in tup])
+            not_after = cert.get("notAfter")
+            if not_after:
+                dt = datetime.datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
+                info["not_after"] = dt.isoformat() + "Z"
+                info["days_to_expiry"] = (dt - datetime.datetime.utcnow()).days
+    return info
+
+async def get_ssh_banner(ip: str, port: int = 22, timeout: float = 2.0) -> str:
+    try:
+        reader, writer = await asyncio.wait_for(asyncio.open_connection(ip, port), timeout)
+        data = await asyncio.wait_for(reader.readline(), timeout)
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+        return data.decode(errors="ignore").strip()[:200]
+    except Exception:
+        return ""

--- a/app/report.py
+++ b/app/report.py
@@ -1,0 +1,63 @@
+from jinja2 import Template
+from datetime import datetime
+
+TPL = Template("""
+<!doctype html><html><head>
+<meta charset="utf-8">
+<title>SMBSEC Report – Scan {{ scan_id }}</title>
+<style>
+ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem; }
+ h1,h2 { margin: 0.2rem 0; }
+ code { background:#f5f5f5; padding:2px 4px; }
+ table { border-collapse: collapse; width:100%; margin:1rem 0;}
+ th,td { border:1px solid #ddd; padding:8px; font-size: 14px; }
+ th { background:#fafafa; text-align:left; }
+ .sev-high { color:#b10000; font-weight:700; }
+ .sev-medium { color:#a36a00; font-weight:700; }
+ .sev-low { color:#1d6f42; font-weight:700; }
+</style>
+</head><body>
+<h1>Security Scan Report</h1>
+<p><strong>Scan ID:</strong> {{ scan_id }} &nbsp; | &nbsp; <strong>Domain:</strong> {{ domain }}
+ &nbsp; | &nbsp; <strong>Finished:</strong> {{ finished }}</p>
+
+{% if stats %}
+<h2>Compliance Score</h2>
+<p><strong>Score:</strong> {{ stats.score }}</p>
+{% if stats.penalties %}
+<p>Penalties:</p>
+<ul>{% for p in stats.penalties %}<li>{{ p }}</li>{% endfor %}</ul>
+{% endif %}
+{% if stats.bonuses %}
+<p>Bonuses:</p>
+<ul>{% for b in stats.bonuses %}<li>{{ b }}</li>{% endfor %}</ul>
+{% endif %}
+{% endif %}
+
+<h2>Assets</h2>
+<table><tr><th>Host</th><th>IP</th><th>Last Seen</th></tr>
+{% for a in assets %}
+<tr><td>{{ a.host }}</td><td>{{ a.ip or '' }}</td><td>{{ a.last_seen }}</td></tr>
+{% endfor %}
+</table>
+
+<h2>Findings</h2>
+<table><tr><th>Severity</th><th>Host</th><th>IP</th><th>Port</th><th>Title</th><th>Details</th></tr>
+{% for f in findings %}
+<tr>
+  <td class="sev-{{ f.severity }}">{{ f.severity }}</td>
+  <td>{{ f.host }}</td>
+  <td>{{ f.ip or '' }}</td>
+  <td>{{ f.port or '' }}</td>
+  <td>{{ f.title }}</td>
+  <td><code>{{ f.description }}</code></td>
+</tr>
+{% endfor %}
+</table>
+
+</body></html>
+""")
+
+def render_report(scan_id:int, domain:str, finished_ts:int, assets:list[dict], findings:list[dict], stats:dict|None)->str:
+    fmt = datetime.utcfromtimestamp(finished_ts).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return TPL.render(scan_id=scan_id, domain=domain, finished=fmt, assets=assets, findings=findings, stats=stats or {})

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -1,0 +1,127 @@
+import asyncio, json, socket
+from typing import Iterable
+import httpx
+import dns.resolver
+from .probers import get_tls_cert_info, get_ssh_banner
+
+DEFAULT_PORTS = [80, 443, 22, 25, 110, 143, 465, 587, 993, 995, 3306, 3389, 5432, 6379, 8080, 8443]
+
+async def fetch_crtsh_subdomains(domain:str)->set[str]:
+    q = f"https://crt.sh/?q=%25.{domain}&output=json"
+    subdomains:set[str] = set()
+    try:
+        async with httpx.AsyncClient(timeout=20) as client:
+            r = await client.get(q, headers={"User-Agent":"smbsec-mvp/1.0"})
+            if r.status_code == 200:
+                for row in r.json():
+                    name_value = row.get("name_value","")
+                    for entry in name_value.split("\n"):
+                        entry = entry.strip().lower().rstrip(".")
+                        if entry.endswith(domain):
+                            subdomains.add(entry)
+    except Exception:
+        pass
+    subdomains.add(domain)
+    return subdomains
+
+def resolve_host(host:str)->list[str]:
+    ips:list[str] = []
+    try:
+        for rdata in dns.resolver.resolve(host, "A"):
+            ips.append(rdata.to_text())
+    except Exception:
+        pass
+    try:
+        for rdata in dns.resolver.resolve(host, "AAAA"):
+            ips.append(rdata.to_text())
+    except Exception:
+        pass
+    return ips
+
+async def tcp_connect(ip:str, port:int, timeout:float=1.0)->bool:
+    try:
+        fut = asyncio.open_connection(ip, port)
+        reader, writer = await asyncio.wait_for(fut, timeout=timeout)
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+        return True
+    except Exception:
+        return False
+
+async def http_fingerprint(host:str, ip:str, scheme:str)->dict:
+    url = f"{scheme}://{host}/"
+    try:
+        async with httpx.AsyncClient(timeout=5, verify=(scheme=="https")) as c:
+            r = await c.get(url, headers={"Host":host, "User-Agent":"smbsec-mvp/1.0"})
+            return {
+                "status": r.status_code,
+                "server": r.headers.get("server",""),
+                "title": (r.text.split("<title>")[1].split("</title>")[0][:200]
+                          if "<title>" in r.text.lower() else "")
+            }
+    except Exception as e:
+        return {"error": str(e)[:200]}
+
+async def bounded_gather(coros:Iterable, limit:int=200):
+    sem = asyncio.Semaphore(limit)
+    async def run(coro):
+        async with sem:
+            return await coro
+    return await asyncio.gather(*[run(c) for c in coros])
+
+async def scan_domain(domain:str):
+    subs = await fetch_crtsh_subdomains(domain)
+    host_ips:dict[str,list[str]] = {}
+    for h in sorted(subs):
+        host_ips[h] = resolve_host(h)
+
+    tcp_results = []
+    for h, ips in host_ips.items():
+        for ip in ips or [None]:
+            for p in DEFAULT_PORTS:
+                if ip:
+                    tcp_results.append((h, ip, p))
+    open_ports:set[tuple[str,str,int]] = set()
+    results = await bounded_gather([tcp_connect(ip, p) for (_, ip, p) in tcp_results], limit=500)
+    for (h, ip, p), ok in zip(tcp_results, results):
+        if ok:
+            open_ports.add((h, ip, p))
+
+    http_fp_tasks = []
+    for (h, ip, p) in open_ports:
+        if p in (80, 8080):
+            http_fp_tasks.append(http_fingerprint(h, ip, "http"))
+        elif p in (443, 8443):
+            http_fp_tasks.append(http_fingerprint(h, ip, "https"))
+    http_fps = await bounded_gather(http_fp_tasks, limit=100)
+
+    fp_iter = iter(http_fps)
+    fingerprints:dict[tuple[str,str,int], dict] = {}
+    for (h, ip, p) in open_ports:
+        if p in (80,8080,443,8443):
+            fingerprints[(h,ip,p)] = next(fp_iter, {})
+
+    tls_info = {}
+    for (h, ip, p) in open_ports:
+        if p in (443, 8443):
+            try:
+                tls_info[f"{h}|{ip}|{p}"] = get_tls_cert_info(h, p)
+            except Exception:
+                tls_info[f"{h}|{ip}|{p}"] = {}
+
+    ssh_targets = [(h, ip, p) for (h, ip, p) in open_ports if p == 22]
+    ssh_banners = await bounded_gather([get_ssh_banner(ip, 22) for (_, ip, _) in ssh_targets], limit=100)
+    ssh_map = {}
+    for (h, ip, p), banner in zip(ssh_targets, ssh_banners):
+        ssh_map[f"{h}|{ip}|{p}"] = banner
+
+    return {
+        "host_ips": host_ips,
+        "open_ports": list(open_ports),
+        "fingerprints": {f"{h}|{ip}|{p}": fp for (h,ip,p), fp in fingerprints.items()},
+        "tls": tls_info,
+        "ssh": ssh_map
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.115.0
+uvicorn==0.30.3
+httpx==0.27.2
+dnspython==2.6.1
+pydantic==2.8.2
+aiosqlite==0.20.0
+jinja2==3.1.4
+boto3==1.34.162
+PyYAML==6.0.2


### PR DESCRIPTION
## Summary
- implement async attack surface scanner with TLS inspection and SSH banner grabbing
- compute compliance score and generate HTML reports
- add AWS CSPM connector to flag public S3 buckets and admin IAM policies

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689f805a1e988322b1d0b4d10a0213f2