### PR TITLE
Implement risk model and S3 public access action

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol
+import boto3
+from botocore.exceptions import ClientError
+
+class Action(Protocol):
+    def preview(self) -> Dict[str, Any]: ...
+    def apply(self) -> Dict[str, Any]: ...
+    def rollback(self) -> Dict[str, Any]: ...
+
+@dataclass
+class S3BlockPublicAction:
+    bucket: str
+    s3_client: boto3.client | None = None
+    _previous: Dict[str, Any] | None = None
+
+    def __post_init__(self):
+        if self.s3_client is None:
+            self.s3_client = boto3.client("s3")
+
+    def preview(self) -> Dict[str, Any]:
+        return {
+            "action": "block_public_access",
+            "bucket": self.bucket,
+            "configuration": {
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            },
+        }
+
+    def apply(self) -> Dict[str, Any]:
+        try:
+            resp = self.s3_client.get_public_access_block(Bucket=self.bucket)
+            self._previous = resp.get("PublicAccessBlockConfiguration", {})
+        except ClientError:
+            self._previous = {}
+        config = {
+            "BlockPublicAcls": True,
+            "IgnorePublicAcls": True,
+            "BlockPublicPolicy": True,
+            "RestrictPublicBuckets": True,
+        }
+        self.s3_client.put_public_access_block(
+            Bucket=self.bucket, PublicAccessBlockConfiguration=config
+        )
+        return config
+
+    def rollback(self) -> Dict[str, Any]:
+        if self._previous is None:
+            raise RuntimeError("apply() must be called before rollback()")
+        if self._previous:
+            self.s3_client.put_public_access_block(
+                Bucket=self.bucket, PublicAccessBlockConfiguration=self._previous
+            )
+        else:
+            try:
+                self.s3_client.delete_public_access_block(Bucket=self.bucket)
+            except ClientError:
+                pass
+        return self._previous

--- a/app/mappings/controls.yaml
+++ b/app/mappings/controls.yaml
@@ -1,0 +1,29 @@
+rdp_exposed:
+  iso27001:
+    - A.13.1.1
+    - A.13.1.3
+  cis:
+    - "9.1"
+    - "9.2"
+db_exposed:
+  iso27001:
+    - A.13.1.1
+    - A.8.2.1
+  cis:
+    - "3.3"
+    - "4.1"
+http_no_tls:
+  iso27001:
+    - A.10.1.1
+  cis:
+    - "9.4"
+tls_expired:
+  iso27001:
+    - A.13.2.3
+  cis:
+    - "4.4"
+ssh_banner_leak:
+  iso27001:
+    - A.13.1.1
+  cis:
+    - "11.2"

--- a/app/risk_model.py
+++ b/app/risk_model.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Any, Dict, List
+import yaml
+
+class RiskModel:
+    """Risk scoring and control mapping for findings."""
+    def __init__(self, mapping_file: str | Path | None = None):
+        if mapping_file is None:
+            mapping_file = Path(__file__).resolve().parent / "mappings" / "controls.yaml"
+        self.mapping_path = Path(mapping_file)
+        with open(self.mapping_path, "r", encoding="utf-8") as f:
+            self.control_map: Dict[str, Dict[str, List[str]]] = yaml.safe_load(f)
+
+    def categorize(self, finding: Dict[str, Any]) -> List[str]:
+        tags: List[str] = []
+        service = str(finding.get("service", "")).lower()
+        port = finding.get("port")
+        if finding.get("tls_expired"):
+            tags.append("tls_expired")
+        if service in ("http", "https") and finding.get("scheme") == "http":
+            tags.append("http_no_tls")
+        if service == "rdp" or port == 3389:
+            tags.append("rdp_exposed")
+        db_ports = {5432, 3306, 1433, 27017}
+        if service in ("postgres", "mysql", "mssql", "mongodb") or port in db_ports:
+            tags.append("db_exposed")
+        if service == "ssh" and finding.get("banner"):
+            tags.append("ssh_banner_leak")
+        return tags
+
+    def map_controls(self, finding: Dict[str, Any]) -> List[Dict[str, str]]:
+        mapped: List[Dict[str, str]] = []
+        ftype = finding.get("type")
+        if not ftype:
+            for tag in self.categorize(finding):
+                if tag in self.control_map:
+                    ftype = tag
+                    break
+        if ftype and ftype in self.control_map:
+            info = self.control_map[ftype]
+            for iso in info.get("iso27001", []):
+                mapped.append({"framework": "ISO27001", "control": iso})
+            for cis in info.get("cis", []):
+                mapped.append({"framework": "CIS", "control": cis})
+        return mapped
+
+    def score(self, finding: Dict[str, Any], asset_ctx: Dict[str, Any]) -> float:
+        severity = float(finding.get("severity_weight", 1))
+        exposure = float(finding.get("exposure", 1))
+        criticality = float(asset_ctx.get("criticality", 1))
+        exploitability = float(finding.get("exploitability_hint", 1))
+        return severity * exposure * criticality * exploitability

--- a/app/state.py
+++ b/app/state.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+def state_transition(prev: Optional[str], curr: Optional[str]) -> Optional[str]:
+    """Return state change given previous and current states.
+
+    States are represented as "open" or "resolved". A missing state is ``None``.
+    Returns "new", "resolved", "regressed" or ``None`` when there is no change.
+    """
+    if prev is None and curr == "open":
+        return "new"
+    if prev == "open" and curr is None:
+        return "resolved"
+    if prev == "resolved" and curr == "open":
+        return "regressed"
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ jinja2==3.1.4
 boto3==1.34.162
 PyYAML==6.0.2
 pdfkit==1.0.0
+pytest==8.2.2
+moto[boto3]==5.0.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_risk_model.py
+++ b/tests/test_risk_model.py
@@ -1,0 +1,19 @@
+from app.risk_model import RiskModel
+
+mapping_file = 'app/mappings/controls.yaml'
+
+rm = RiskModel(mapping_file)
+
+def test_categorize_and_map_controls():
+    finding = {"service": "rdp", "port": 3389}
+    tags = rm.categorize(finding)
+    assert "rdp_exposed" in tags
+    controls = rm.map_controls({"type": "rdp_exposed"})
+    assert {"framework": "ISO27001", "control": "A.13.1.1"} in controls
+    assert {"framework": "CIS", "control": "9.1"} in controls
+
+def test_score():
+    finding = {"severity_weight": 5, "exposure": 2, "exploitability_hint": 1.5}
+    asset = {"criticality": 3}
+    score = rm.score(finding, asset)
+    assert score == 5 * 2 * 3 * 1.5

--- a/tests/test_s3_block_public_action.py
+++ b/tests/test_s3_block_public_action.py
@@ -1,0 +1,28 @@
+import pytest
+import boto3
+from botocore.exceptions import ClientError
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    mock_aws = None
+
+from app.actions import S3BlockPublicAction
+
+@pytest.mark.skipif(mock_aws is None, reason="moto not installed")
+def test_preview_apply_rollback():
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="test-bucket")
+        action = S3BlockPublicAction("test-bucket", s3_client=s3)
+
+        preview = action.preview()
+        assert preview["bucket"] == "test-bucket"
+
+        action.apply()
+        cfg = s3.get_public_access_block(Bucket="test-bucket")
+        assert cfg["PublicAccessBlockConfiguration"]["BlockPublicAcls"] is True
+
+        action.rollback()
+        with pytest.raises(ClientError):
+            s3.get_public_access_block(Bucket="test-bucket")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,13 @@
+from app.state import state_transition
+
+def test_new():
+    assert state_transition(None, "open") == "new"
+
+def test_resolved():
+    assert state_transition("open", None) == "resolved"
+
+def test_regressed():
+    assert state_transition("resolved", "open") == "regressed"
+
+def test_unchanged():
+    assert state_transition("open", "open") is None


### PR DESCRIPTION
## Summary
- add RiskModel with control mapping and scoring
- define state_transition helper for finding lifecycle
- implement S3BlockPublicAction with preview/apply/rollback
- include ISO/CIS mapping tables
- add pytest suite for new modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8b447b54832285647816ca5b20ee