### PR TITLE
Extend asset metadata and owner workflow integration

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,4 +1,6 @@
 import aiosqlite, asyncio, json, os, time
+from . import fix_queue
+
 DB_PATH = os.path.join(os.path.dirname(__file__), "..", "data.db")
 
 SCHEMA = """
@@ -16,6 +18,9 @@ CREATE TABLE IF NOT EXISTS assets(
   scan_id INTEGER NOT NULL,
   host TEXT NOT NULL,
   ip TEXT,
+  owner_email TEXT,
+  criticality INTEGER,
+  data_class TEXT,
   first_seen INTEGER NOT NULL,
   last_seen INTEGER NOT NULL,
   UNIQUE(scan_id, host, ip)
@@ -62,25 +67,43 @@ async def finish_scan(scan_id:int, status:str, stats:dict):
                          (int(time.time()), status, json.dumps(stats), scan_id))
         await db.commit()
 
-async def upsert_asset(scan_id:int, host:str, ip:str|None):
+async def upsert_asset(scan_id:int, host:str, ip:str|None, *, owner_email:str|None=None,
+                       criticality:int|None=None, data_class:str|None=None):
     now = int(time.time())
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
-            "INSERT OR IGNORE INTO assets(scan_id,host,ip,first_seen,last_seen) VALUES(?,?,?,?,?)",
-            (scan_id, host, ip, now, now))
+            "INSERT OR IGNORE INTO assets(scan_id,host,ip,owner_email,criticality,data_class,first_seen,last_seen) VALUES(?,?,?,?,?,?,?,?)",
+            (scan_id, host, ip, owner_email, criticality, data_class, now, now))
         await db.execute(
-            "UPDATE assets SET last_seen=? WHERE scan_id=? AND host=? AND ifnull(ip,'')=ifnull(?, '')",
-            (now, scan_id, host, ip))
+            """
+            UPDATE assets SET last_seen=?,
+                owner_email=COALESCE(?,owner_email),
+                criticality=COALESCE(?,criticality),
+                data_class=COALESCE(?,data_class)
+            WHERE scan_id=? AND host=? AND ifnull(ip,'')=ifnull(?, '')
+            """,
+            (now, owner_email, criticality, data_class, scan_id, host, ip))
         await db.commit()
 
 async def add_finding(scan_id:int, host:str, ip:str|None, port:int|None, proto:str|None,
                       severity:str, title:str, description:str, evidence:dict):
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("""INSERT INTO findings
+        cur = await db.execute("""INSERT INTO findings
             (scan_id,host,ip,port,proto,severity,title,description,evidence_json,created_at)
             VALUES(?,?,?,?,?,?,?,?,?,?)""",
             (scan_id,host,ip,port,proto,severity,title,description,json.dumps(evidence),int(time.time())))
+        finding_id = cur.lastrowid
+        owner_email = None
+        cur = await db.execute(
+            "SELECT owner_email FROM assets WHERE scan_id=? AND host=? AND ifnull(ip,'')=ifnull(?, '')",
+            (scan_id, host, ip))
+        row = await cur.fetchone()
+        if row:
+            owner_email = row[0]
         await db.commit()
+    if severity in ("high", "critical"):
+        fix_queue.add(finding_id, owner_email, severity, title, description)
+        fix_queue.open_jira_ticket(finding_id, title, description, owner_email)
 
 async def get_scan(scan_id:int)->dict|None:
     async with aiosqlite.connect(DB_PATH) as db:

--- a/app/fix_queue.py
+++ b/app/fix_queue.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import os
+import httpx
+
+FIX_QUEUE: list[dict] = []
+
+def add(finding_id:int, owner_email:str|None, severity:str, title:str, description:str) -> dict:
+    entry = {
+        "finding_id": finding_id,
+        "owner_email": owner_email,
+        "severity": severity,
+        "title": title,
+        "description": description,
+    }
+    FIX_QUEUE.append(entry)
+    return entry
+
+def open_jira_ticket(finding_id:int, title:str, description:str, owner_email:str|None):
+    url = os.environ.get("JIRA_URL")
+    user = os.environ.get("JIRA_USER")
+    token = os.environ.get("JIRA_TOKEN")
+    if not url or not user or not token:
+        return None
+    payload = {
+        "fields": {
+            "project": {"key": "SEC"},
+            "summary": title,
+            "description": description,
+            "issuetype": {"name": "Task"},
+        }
+    }
+    if owner_email:
+        payload["fields"]["reporter"] = {"emailAddress": owner_email}
+    resp = httpx.post(f"{url}/rest/api/2/issue", json=payload, auth=(user, token))
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("key")

--- a/tests/test_owner_propagation.py
+++ b/tests/test_owner_propagation.py
@@ -1,0 +1,29 @@
+import asyncio
+from fastapi.testclient import TestClient
+from app import db, main, fix_queue
+
+def test_owner_propagates_to_fix_queue(tmp_path, monkeypatch):
+    db.DB_PATH = str(tmp_path / "test.db")
+    asyncio.run(db.init_db())
+    scan_id = asyncio.run(db.create_scan("example.com"))
+    client = TestClient(main.app)
+    payload = {
+        "scan_id": scan_id,
+        "host": "h1",
+        "ip": "1.1.1.1",
+        "owner_email": "owner@example.com",
+        "criticality": 5,
+        "data_class": "PII"
+    }
+    resp = client.post("/org/scope", json=payload)
+    assert resp.status_code == 200
+    fix_queue.FIX_QUEUE.clear()
+    called = {}
+    def fake_jira(*args, **kwargs):
+        called["called"] = True
+    monkeypatch.setattr(fix_queue, "open_jira_ticket", fake_jira)
+    asyncio.run(db.add_finding(scan_id, "h1", "1.1.1.1", 80, "tcp", "high", "issue", "desc", {}))
+    assert fix_queue.FIX_QUEUE
+    entry = fix_queue.FIX_QUEUE[0]
+    assert entry["owner_email"] == "owner@example.com"
+    assert called.get("called")


### PR DESCRIPTION
## Summary
- track owner email, criticality and data classification on assets
- route `/org/scope` accepts owner metadata and persists it
- fix queue records owner emails and opens Jira tickets for high-severity findings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f97741e1c8322b1d75cf93c710c5f