### PR TITLE
Add risk scoring and fix queue

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -31,6 +31,8 @@ CREATE TABLE IF NOT EXISTS findings(
   title TEXT NOT NULL,
   description TEXT NOT NULL,
   evidence_json TEXT NOT NULL DEFAULT '{}',
+  risk_score REAL NOT NULL DEFAULT 0,
+  controls_json TEXT NOT NULL DEFAULT '{}',
   created_at INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS connectors(
@@ -74,12 +76,13 @@ async def upsert_asset(scan_id:int, host:str, ip:str|None):
         await db.commit()
 
 async def add_finding(scan_id:int, host:str, ip:str|None, port:int|None, proto:str|None,
-                      severity:str, title:str, description:str, evidence:dict):
+                      severity:str, title:str, description:str, evidence:dict,
+                      risk_score:float, controls:dict):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("""INSERT INTO findings
-            (scan_id,host,ip,port,proto,severity,title,description,evidence_json,created_at)
-            VALUES(?,?,?,?,?,?,?,?,?,?)""",
-            (scan_id,host,ip,port,proto,severity,title,description,json.dumps(evidence),int(time.time())))
+            (scan_id,host,ip,port,proto,severity,title,description,evidence_json,risk_score,controls_json,created_at)
+            VALUES(?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (scan_id,host,ip,port,proto,severity,title,description,json.dumps(evidence),risk_score,json.dumps(controls),int(time.time())))
         await db.commit()
 
 async def get_scan(scan_id:int)->dict|None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,30 @@
+import json
+import re
+from app.report import render_report
+
+
+def test_fix_queue_sorted():
+    scores = [5, 1, 9, 3, 7, 8]
+    findings = []
+    for idx, sc in enumerate(scores):
+        findings.append({
+            "severity": "low",
+            "host": f"h{idx}",
+            "ip": None,
+            "port": None,
+            "title": f"t{idx}",
+            "description": f"d{idx}",
+            "risk_score": sc,
+            "controls_json": json.dumps({"iso27001": [], "cis_controls": []})
+        })
+    html = render_report(1, "example.com", 0, [], findings, {})
+    m = re.search(r"<h2>Fix Queue</h2>\s*<table.*?>(.*?)</table>", html, re.S)
+    assert m, "Fix Queue section missing"
+    section = m.group(1)
+    rows = re.findall(
+        r"<tr>\s*<td>.*?</td>\s*<td>.*?</td>\s*<td>.*?</td>\s*<td>(.*?)</td>\s*<td>.*?</td>\s*</tr>",
+        section,
+        re.S,
+    )
+    scores_rendered = [float(x) for x in rows]
+    assert scores_rendered == sorted(scores, reverse=True)[:5]


### PR DESCRIPTION
## Summary
- store risk score and control mappings for findings
- compute risk scores for all findings and surface top issues in a Fix Queue section
- ensure report fix queue orders items by highest risk first

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f97721f188322ba3b8c197bad5e03